### PR TITLE
Add `additional_user_data` and `additional_users` inputs, recreate ASG and EC2 on launch config updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.3.0]
+### Added
+
+* A new `additional_users` module input allows specifying additional SSH users to be created. The available per-user fields are login, gecos (full name), shell, supplemental groups, and SSH authorized\_keys.
+* A new `additional_user-data` input allows specifying content to add toward the end of EC2 User Data. The additional User Data is executed before additional users are added.
+
+### Changed
+
+* The Auto Scaling Group (and its bastion EC2) will now be recreated when there is an update to the Launch Configuration. The new Auto Scaling Group will be created before the current one is deleted. Previously the EC2 would remain untouched, leaving its recycling to operator discretion.
+
+### Fixed
+
+* The Launch Configuration lifecycle block incorrectly specified ignoring `image_id` - a new AMI will not cause the Launch Configuration to be recreated, as originally intended. Recycling the EC2 due to a new AMI should be less necessary as this module enables automatic Ubuntu updates.
+
 ## [0.2.0]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Default: `""`
 
 #### additional\_users
 
-Description: Additional users to be created on the bastion. Specify users as a list of maps. See an example in the `example-usage` file. Required map keys are `login` and `authorized_keys`. Optional map keys are `gecos`, `supplemental_groups` (comma-separated), and `shell`. The authorized_keys will be output to ~/.ssh/authorized_keys using printf - multiple keys can be specified by including \n in the string.
+Description: Additional users to be created on the bastion. Specify users as a list of maps. See an example in the `example-usage` file. Required map keys are `login` (user name) and `authorized_keys`. Optional map keys are `gecos` (full name), `supplemental_groups` (comma-separated), and `shell`. The authorized_keys will be output to ~/.ssh/authorized_keys using printf - multiple keys can be specified by including \n in the string.
 
 Type: `list`
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The Ubuntu 18.04 EC2 instance is configured as follows:
 * A host record, named using the `bastion_name` module input,  is added to a configurable Route53 DNS zone for the current public IP address of the bastion. This happens via a script configured to run on boot.
 * Automatic updates are configured, using a configurable time to reboot, and the email address to receive errors.
 * By default sudo access is removed from the ubuntu user unless the `remove_root_access` input is set to "false."
+* Additional EC2 User Data can be executed, for one-off configuration not included in this module.
+* Additional users can be created and populated with their own `authorized_keys` file.
 
 ## Using The Bastion
 ### SSH Access to Kubernetes Nodes
@@ -117,6 +119,26 @@ Type: `list`
 ### Optional Inputs
 
 The following input variables are optional (have default values):
+
+#### additional\_user\_data
+
+Description: Content to be appended to UserData, which is run the first time the bastion EC2 boots.
+
+Type: `string`
+
+Default: `""`
+
+#### additional\_users
+
+Description: Additional users to be created on the bastion. Specify users as a list of maps. See an example in the `example-usage` file. Required map keys are `login` and `authorized_keys`. Optional map keys are `gecos`, `supplemental_groups` (comma-separated), and `shell`. The authorized_keys will be output to ~/.ssh/authorized_keys using printf - multiple keys can be specified by including \n in the string.
+
+Type: `list`
+
+Default:
+
+```json
+[]
+```
 
 #### bastion\_name
 

--- a/README.pre_tf_inputs.md
+++ b/README.pre_tf_inputs.md
@@ -12,6 +12,8 @@ The Ubuntu 18.04 EC2 instance is configured as follows:
 * A host record, named using the `bastion_name` module input,  is added to a configurable Route53 DNS zone for the current public IP address of the bastion. This happens via a script configured to run on boot.
 * Automatic updates are configured, using a configurable time to reboot, and the email address to receive errors.
 * By default sudo access is removed from the ubuntu user unless the `remove_root_access` input is set to "false."
+* Additional EC2 User Data can be executed, for one-off configuration not included in this module.
+* Additional users can be created and populated with their own `authorized_keys` file.
 
 ## Using The Bastion
 ### SSH Access to Kubernetes Nodes

--- a/additional_user.tf
+++ b/additional_user.tf
@@ -1,0 +1,37 @@
+# This template data source is created for each user specified in the additional_users module input.
+# The below template(s) will be rendered in the bastion-userdata.tmpl template.
+data "template_file" "additional_user" {
+  count = "${length(var.additional_users)}"
+
+  vars {
+    # The additional_users input is a list of maps.
+    user_login               = "${lookup(var.additional_users[count.index], "login")}"
+    # If gecos is nset, default to the user-name.
+    user_gecos               = "${lookup(var.additional_users[count.index], "gecos", lookup(var.additional_users[count.index], "login"))}"
+    # If shell is isn't set, default to bash.
+    user_shell               = "${lookup(var.additional_users[count.index], "shell", "/bin/bash")}"
+    user_supplemental_groups = "${lookup(var.additional_users[count.index], "supplemental_groups", "")}"
+    user_authorized_keys     = "${lookup(var.additional_users[count.index], "authorized_keys")}"
+  }
+
+  template = <<EOF
+info "Creating user:"
+# The printf string is put in single-quotes because it may contain it's own double-quotes.
+printf '  Login: \"$${user_login}\"\n  Gecos: \"$${user_gecos}\"\n  Shell: \"$${user_shell}\"\n  Supplemental Groups: \"$${user_supplemental_groups}\"\n  Authorized Keys: \"$${user_authorized_keys}\"\n'
+
+# The ssh_keys variable is put in single-quotes because it may contain it's own double-quotes.
+if [ "$${user_login}x" == "x" -o '$${user_authorized_keys}x' == "x" ] ; then
+  info "Both login and authorized_keys are required - the above user will not be created."
+else
+  useradd -s $${user_shell} -c "$${user_gecos}" -m $${user_login}
+  [ "$${user_supplemental_groups}x" != "x" ] && usermod -G $${user_supplemental_groups} $${user_login}
+  info "Populating authorized_keys for $${user_login}"
+  mkdir ~$${user_login}/.ssh
+  # The ssh_keys variable is put in single-quotes because it may contain it's own double-quotes.
+  printf '$${user_authorized_keys}' > ~$${user_login}/.ssh/authorized_keys
+  chown -R $${user_login}:$${user_login} ~$${user_login}/.ssh
+  chmod -R go= ~$${user_login}/.ssh
+fi
+
+EOF
+}

--- a/auto-scaling.tf
+++ b/auto-scaling.tf
@@ -2,7 +2,9 @@
 # replacing an unhealthy EC2 instance or recovering from an
 # availability zone failure.
 resource "aws_autoscaling_group" "bastion" {
-  name_prefix          = "${var.bastion_name}-"
+  # The Launch Configuration ID is part of the AUto Scalign Group name,
+  # to force the ASG and its EC2 to be recreated.
+  name                 = "asg-${aws_launch_configuration.bastion.id}"
   launch_configuration = "${aws_launch_configuration.bastion.name}"
   min_size             = 1
   max_size             = 1

--- a/bastion-userdata.tmpl
+++ b/bastion-userdata.tmpl
@@ -121,6 +121,19 @@ Unattended-Upgrade::Mail "${unattended_upgrade_email_recipient}";
 ${unattended_upgrade_additional_configs}
 EOF
 
+# Execute optional additional user data.
+if [ "$${additional_user_data}x" == "x" ] ; then
+  info "Executing additional_user_data. . ."
+  ${additional_user_data}
+  info "Finished executing additional_user_data. . ."
+fi
+
+# Add optional additional users and authorized_keys,
+# specified in the additional_users module input as a list of maps.
+# This variable is set to the rendering of all additional user templates,
+# which are shell commands to be executed to create and configure the users.
+${additional_user_templates}
+
 # Use a temporary variable to more easily compare the lowercase remove_root_access input.
 rra=$(echo ${remove_root_access} |tr '[:upper:]' '[:lower:]')
 if test $rra == "true" -o $rra == "yes" -o $rra == "1" ; then

--- a/example-usage
+++ b/example-usage
@@ -1,4 +1,7 @@
 # Example usage for this terraform-bastion module.
+# This example does not use all possible module inputs,
+# please see [README.md](./README.md) for descriptions of all inputs.
+
 module "bastion" {
   # Replace v0.2.0 below, with a version number from https://github.com/reactiveops/terraform-bastion/releases
   source = "git@github.com:reactiveops/terraform-bastion.git?ref=v0.2.0"
@@ -21,4 +24,19 @@ module "bastion" {
   # This uses an SSH public key from the Terraform root module directory.
   ssh_public_key_file                = "${file("${path.root}/bastion_ssh.pub")}"
   unattended_upgrade_email_recipient = "you@example.com"
+
+  # Execute additional commands during User Data, for this bastion.
+  additional_user_data = <<EOD
+apt-get update && apt-get install -y zsh
+EOD
+
+  # Create an additional SSH user for Continuous Integration.
+  # The SSH authorized_keys will not allow commands to be run.
+  additional_users = [
+    {
+      login           = "ci"
+      gecos           = "CI access to private Kubernetes API"
+      authorized_keys = "command=\"echo This account is only for CI port forwarding, there is no shell access. Press ENTER when you are ready to disconnect. . .;read junk\" ssh-rsa xxxxx..."
+    },
+  ]
 }

--- a/inputs.tf
+++ b/inputs.tf
@@ -34,6 +34,17 @@ variable "remove_root_access" {
   default = "true"
 }
 
+variable "additional_users" {
+  type        = "list"
+  description = "Additional users to be created on the bastion. Specify users as a list of maps. See an example in the `example-usage` file. Required map keys are `login` and `authorized_keys`. Optional map keys are `gecos`, `supplemental_groups` (comma-separated), and `shell`. The authorized_keys will be output to ~/.ssh/authorized_keys using printf - multiple keys can be specified by including \\n in the string."
+  default = []
+}
+
+variable "additional_user_data" {
+  description = "Content to be appended to UserData, which is run the first time the bastion EC2 boots."
+  default     = ""
+}
+
 variable "instance_type" {
   description = "The EC2 instance type of the bastion."
   default     = "t2.micro"

--- a/inputs.tf
+++ b/inputs.tf
@@ -36,7 +36,7 @@ variable "remove_root_access" {
 
 variable "additional_users" {
   type        = "list"
-  description = "Additional users to be created on the bastion. Specify users as a list of maps. See an example in the `example-usage` file. Required map keys are `login` and `authorized_keys`. Optional map keys are `gecos`, `supplemental_groups` (comma-separated), and `shell`. The authorized_keys will be output to ~/.ssh/authorized_keys using printf - multiple keys can be specified by including \\n in the string."
+  description = "Additional users to be created on the bastion. Specify users as a list of maps. See an example in the `example-usage` file. Required map keys are `login` (user name) and `authorized_keys`. Optional map keys are `gecos` (full name), `supplemental_groups` (comma-separated), and `shell`. The authorized_keys will be output to ~/.ssh/authorized_keys using printf - multiple keys can be specified by including \\n in the string."
   default = []
 }
 

--- a/launchconfig.tf
+++ b/launchconfig.tf
@@ -35,7 +35,7 @@ resource "aws_launch_configuration" "bastion" {
   security_groups             = ["${aws_security_group.bastion_ssh.id}"]
   associate_public_ip_address = "true"
 
-  user_data = "${data.template_file.bastion_user_data.rendered}"
+  user_data_base64 = "${base64gzip(data.template_file.bastion_user_data.rendered)}"
   key_name  = "${aws_key_pair.bastion.id}"
 
   lifecycle {

--- a/launchconfig.tf
+++ b/launchconfig.tf
@@ -14,7 +14,11 @@ data "template_file" "bastion_user_data" {
     unattended_upgrade_email_recipient    = "${var.unattended_upgrade_email_recipient}"
     unattended_upgrade_additional_configs = "${var.unattended_upgrade_additional_configs}"
 
-    remove_root_access = "${var.remove_root_access}"
+    remove_root_access   = "${var.remove_root_access}"
+    additional_user_data = "${var.additional_user_data}"
+
+    # Join the rendered templates per additional user into a single string variable.
+    additional_user_templates = "${join("\n", data.template_file.additional_user.*.rendered)}"
   }
 }
 


### PR DESCRIPTION
* A new `additional_users` module input allows specifying additional SSH users to be created. The available per-user fields are login, gecos (full name), shell, supplemental groups, and SSH authorized\_keys.
* A new `additional_user-data` input allows specifying content to add toward the end of EC2 User Data. The additional User Data is executed before additional users are added.
* The Auto Scaling Group (and its bastion EC2) will now be recreated when there is an update to the Launch Configuration. The new Auto Scaling Group will be created before the current one is deleted. Previously the EC2 would remain untouched, leaving its recycling to operator discretion.
