### PR TITLE
Ignore tags on the SSH security group

### DIFF
--- a/security-group.tf
+++ b/security-group.tf
@@ -17,4 +17,8 @@ resource "aws_security_group" "bastion_ssh" {
   }
 
   vpc_id = "${var.vpc_id}"
+
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
 }


### PR DESCRIPTION
In cases where an outside process tags the security group regarding
allowing SSH access from the Internet, these tags should be ignored and
left in place.