### PR TITLE
Fixing apt install prompt issues.  Fixes #6

### DIFF
--- a/additional_user.tf
+++ b/additional_user.tf
@@ -5,9 +5,11 @@ data "template_file" "additional_user" {
 
   vars {
     # The additional_users input is a list of maps.
-    user_login               = "${lookup(var.additional_users[count.index], "login")}"
+    user_login = "${lookup(var.additional_users[count.index], "login")}"
+
     # If gecos is nset, default to the user-name.
-    user_gecos               = "${lookup(var.additional_users[count.index], "gecos", lookup(var.additional_users[count.index], "login"))}"
+    user_gecos = "${lookup(var.additional_users[count.index], "gecos", lookup(var.additional_users[count.index], "login"))}"
+
     # If shell is isn't set, default to bash.
     user_shell               = "${lookup(var.additional_users[count.index], "shell", "/bin/bash")}"
     user_supplemental_groups = "${lookup(var.additional_users[count.index], "supplemental_groups", "")}"

--- a/auto-scaling.tf
+++ b/auto-scaling.tf
@@ -4,7 +4,8 @@
 resource "aws_autoscaling_group" "bastion" {
   # The Launch Configuration ID is part of the AUto Scalign Group name,
   # to force the ASG and its EC2 to be recreated.
-  name                 = "asg-${aws_launch_configuration.bastion.id}"
+  name = "asg-${aws_launch_configuration.bastion.id}"
+
   launch_configuration = "${aws_launch_configuration.bastion.name}"
   min_size             = 1
   max_size             = 1

--- a/bastion-userdata.tmpl
+++ b/bastion-userdata.tmpl
@@ -7,18 +7,20 @@ function info {
 }
 
 
-# RE: the UCF options below,                                                    
+# RE: the UCF options below,
 # see https://askubuntu.com/questions/146921/how-do-i-apt-get-y-dist-upgrade-without-a-grub-config-prompt
-# Keep the old menu.lst file as it provides EC2 console output.                 
-export UCF_FORCE_CONFFOLD=yes                                                   
-ucf --purge /boot/grub/menu.lst                                                 
+# Keep the old menu.lst file as it provides EC2 console output.
+export UCF_FORCE_CONFFOLD=yes
+export UCF_FORCE_CONFFNEW=yes
+ucf --purge /boot/grub/menu.lst
+export DEBIAN_FRONTEND=noninteractive
 info Updating packages. . .
-apt-get update -y
-apt-get upgrade -y                                                              
-apt-get dist-upgrade -y
+apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" update
+apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
+apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
 
 info Installing packages needed on the bastion...
-apt-get install -y awscli python unattended-upgrades
+apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install awscli python unattended-upgrades
 
 info The infra bucket is: ${infrastructure_bucket} and the S3 key is ${infrastructure_bucket_bastion_key}
 

--- a/inputs.tf
+++ b/inputs.tf
@@ -37,7 +37,7 @@ variable "remove_root_access" {
 variable "additional_users" {
   type        = "list"
   description = "Additional users to be created on the bastion. Specify users as a list of maps. See an example in the `example-usage` file. Required map keys are `login` (user name) and `authorized_keys`. Optional map keys are `gecos` (full name), `supplemental_groups` (comma-separated), and `shell`. The authorized_keys will be output to ~/.ssh/authorized_keys using printf - multiple keys can be specified by including \\n in the string."
-  default = []
+  default     = []
 }
 
 variable "additional_user_data" {

--- a/launchconfig.tf
+++ b/launchconfig.tf
@@ -36,7 +36,7 @@ resource "aws_launch_configuration" "bastion" {
   associate_public_ip_address = "true"
 
   user_data_base64 = "${base64gzip(data.template_file.bastion_user_data.rendered)}"
-  key_name  = "${aws_key_pair.bastion.id}"
+  key_name         = "${aws_key_pair.bastion.id}"
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
Most important - export DEBIAN_FRONTEND=noninteractive

Also a terraform fmt and adding more dpkg options to the apt commands.